### PR TITLE
fix: stop making packages private during the pre-release workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# editorconfig.org
+# top-most EditorConfig file for this level
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+
+[*.{md,mdx}]
+trim_trailing_whitespace = false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: "daily"
       time: "07:00"
       timezone: "America/New_York"
+    commit-message: # Prefix all commit messages with "actions: "
+      prefix: "actions"
     labels:
       - "actions"
       - "dependabot"
@@ -13,3 +15,7 @@ updates:
       - "jeffsays"
     reviewers:
       - "jeffsays"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/package-prerelease.yml
+++ b/.github/workflows/package-prerelease.yml
@@ -7,6 +7,11 @@ on:
         required: false
         type: string
         default: "ubuntu-latest"
+      access:
+        description: "The access for the published package (public or restricted)"
+        required: false
+        type: string
+        default: "public"
       githubEventName:
         required: false
         type: string
@@ -76,13 +81,13 @@ jobs:
       # publish
       - name: Publish (packages/hybrid)
         if: inputs.workspaces != 'true' && inputs.workspace == ''
-        run: yarn npm publish --tag ${{ steps.feature.outputs.stage }}
+        run: yarn npm publish --access ${{ inputs.access }} --tag ${{ steps.feature.outputs.stage }}
       - name: Publish (all workspaces)
         if: inputs.workspaces == 'true' && inputs.workspace == ''
-        run: yarn workspaces foreach --no-private npm publish --tag ${{ steps.feature.outputs.stage }}
+        run: yarn workspaces foreach --no-private npm publish --tag ${{ steps.feature.outputs.stage }} --access ${{ inputs.access }}
       - name: Publish ${{ inputs.workspace }}
         if: inputs.workspaces != 'true' && inputs.workspace != ''
-        run: yarn workspaces foreach --include ${{ inputs.workspace }} run publish --tag ${{ steps.feature.outputs.stage }}
+        run: yarn workspaces foreach --include ${{ inputs.workspace }} run publish --tag ${{ steps.feature.outputs.stage }} --access ${{ inputs.access }}
       # $GITHUB_STEP_SUMMARY
       - name: Summary (packages/hybrid)
         if: inputs.workspaces != 'true' && inputs.workspace == ''
@@ -102,9 +107,9 @@ jobs:
         run: |
           pjs=($(find . -type f -name package.json -not -path "./node_modules/*"))
           echo "package.json files found: ${pjs[@]}"
-          
+
           for version in "${pjs[@]}"; do
-            if [[ "$(jq -r '.name' ${version})" == "${{ inputs.workspace }}" ]]; then 
+            if [[ "$(jq -r '.name' ${version})" == "${{ inputs.workspace }}" ]]; then
               echo "### Published $(jq '.name' ${version}) version $(jq '.version' ${version}) to NPM" >> "$GITHUB_STEP_SUMMARY"
             fi
           done

--- a/.github/workflows/package-unit.yml
+++ b/.github/workflows/package-unit.yml
@@ -8,7 +8,7 @@ on:
         type: string
         default: "false"
       workspace:
-        description: "specific workspoace to run against"
+        description: "specific workspace to run against"
         required: false
         type: string
         default: ""

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,17 @@
+shell=bash
+
+# don't warn over "<variable> is referenced but not assigned"
+# as the assignments come from actions.yml as env vars
+disable=SC2154
+
+enable=all                        # Enable all optional checks.
+enable=add-default-case           # Suggest adding a default case in `case` statements
+enable=avoid-nullary-conditions   # Suggest explicitly using -n in `[ $var ]`
+enable=check-extra-masked-returns # Check for additional cases where exit codes are masked
+enable=check-set-e-suppressed     # Notify when set -e is suppressed during function invocation
+enable=check-unassigned-uppercase # Turn on warnings for unassigned uppercase variables
+enable=deprecate-which            # Suggest 'command -v' instead of 'which'
+enable=quote-safe-variables       # Turn on warnings for unquoted variables with safe values
+enable=require-double-brackets    # Require [[ and warn about [ in Bash/Ksh
+enable=require-variable-braces    # Suggest ${VAR} in place of $VAR
+enable=useless-use-of-cat         # Check for Useless Use Of Cat (UUOC)


### PR DESCRIPTION
# Summary
## What does this PR do?
- fix: stop making packages private on npmjs during the pre-release workflow
  - closes CumulusDS/aws-cloudformation-wait-ready#53
- add `.editorconfig` file
- add `.shellcheckrc` file
- update dependabot configuration

# Details
## Why did you make this change? What does it affect?
The [publish workflow](https://github.com/CumulusDS/workflows-public/commit/7beaa8edee304493662f777128c6b76e7a1762da) was updated to not have the default access as `restricted`, however this wasn't also added to the pre-release publish workflow


# Testing
## How can the other reviewers check that your change works?
...it should stop marking public packages as private unintentionally